### PR TITLE
Rough implementation of module-relative resolution

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -54,7 +54,7 @@ var workerTableNextAvailable workerTableIndex = 0
 type ReceiveMessageCallback func(msg []byte) []byte
 
 // To resolve modules from javascript.
-type ModuleResolverCallback func(moduleName, referrerName string) int
+type ModuleResolverCallback func(moduleName, referrerName string) (string, int)
 
 // Don't init V8 more than once.
 var initV8Once sync.Once
@@ -134,7 +134,7 @@ func recvCb(buf unsafe.Pointer, buflen C.int, index workerTableIndex) C.buf {
 }
 
 //export ResolveModule
-func ResolveModule(moduleSpecifier *C.char, referrerSpecifier *C.char, resolverToken int) C.int {
+func ResolveModule(moduleSpecifier *C.char, referrerSpecifier *C.char, resolverToken int) (*C.char, C.int) {
 	moduleName := C.GoString(moduleSpecifier)
 	// TODO: Remove this when I'm not dealing with Node resolution anymore
 	referrerName := C.GoString(referrerSpecifier)
@@ -144,10 +144,11 @@ func ResolveModule(moduleSpecifier *C.char, referrerSpecifier *C.char, resolverT
 	resolverTableLock.Unlock()
 
 	if resolve == nil {
-		return C.int(1)
+		return nil, C.int(1)
 	}
-	ret := resolve(moduleName, referrerName)
-	return C.int(ret)
+	canon, ret := resolve(moduleName, referrerName)
+
+	return C.CString(canon), C.int(ret)
 }
 
 // Creates a new worker, which corresponds to a V8 isolate. A single threaded

--- a/worker_test.go
+++ b/worker_test.go
@@ -226,7 +226,7 @@ func TestModules(t *testing.T) {
 	err2 := worker.LoadModule("code.js", `
 		import { test } from "dependency.js";
 		V8Worker2.print(test);
-	`, func(specifier string, referrer string) int {
+	`, func(specifier string, referrer string) (string, int) {
 		if specifier != "dependency.js" {
 			t.Fatal(`Expected "dependency.js" specifier`)
 		}
@@ -235,14 +235,14 @@ func TestModules(t *testing.T) {
 		}
 		err1 := worker.LoadModule("dependency.js", `
 			export const test = "ready";
-		`, func(_, _ string) int {
+		`, func(_, _ string) (string, int) {
 			t.Fatal(`Expected module resolver callback to not be called`)
-			return 1
+			return "", 1
 		})
 		if err1 != nil {
 			t.Fatal(err1)
 		}
-		return 0
+		return "dependency.js", 0
 	})
 	if err2 != nil {
 		t.Fatal(err2)
@@ -257,11 +257,11 @@ func TestModulesMissingDependency(t *testing.T) {
 	err := worker.LoadModule("code.js", `
 		import { test } from "missing.js";
 		V8Worker2.print(test);
-	`, func(specifier string, referrer string) int {
+	`, func(specifier string, referrer string) (string, int) {
 		if specifier != "missing.js" {
 			t.Fatal(`Expected "missing.js" specifier`)
 		}
-		return 1
+		return "", 1
 	})
 	errorContains(t, err, "missing.js")
 }


### PR DESCRIPTION
We would like to allow modules to import from relative paths, e.g.,

    import mod from './mod';

As things stand, module specifiers (the `'./mod'` bit above) are
treated as globally identifying a module, no matter where they are
used. This means:

 - the same module file, imported using different specifiers, loads a
   module twice;
 - same specifier used from different places should refer to different
   modules, but will use the same cached module.

To fix this, we need to map a specifier into something that _does_
properly identify the particular module, from wherever it's
called. The absolute filesystem path (or other plausibly canonical
path) is a good candidate; but as the code stands, there are a couple
of problems:

 1. it's the ModuleResolverCallback (supplied by the client Go code) that
 does the work of finding a module, so that's where the ID has to come
 from.

 2. the ResolverCallback (in C++ code) used by
 Module::InstantiateModule to get the dependencies of a module can't
 have any state associated with it.

To get around these, we have to 1. pass the canonical path back from
the ModuleResolverCallback; and 2. keep track of what each specifier
resolved to, for each module.