### PR TITLE
Put the working dir on the pkgconfig path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install: |
 install:
   - ./build.py --use_ccache
 script:
-  - go test -v
+  - PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PWD go test -v


### PR DESCRIPTION
After building the v8 lib (with ./build.py), the pkgconfig file (v8.pc) ends up in the working directory. To compile any Go code (e.g., to run the tests), that needs to be on the pkgconfig search path.