### PR TITLE
Print errors etc., to stderr, and add V8Worker2.log method for printing to stderr from JS

### DIFF
--- a/worker_test.go
+++ b/worker_test.go
@@ -53,6 +53,17 @@ func TestPrint(t *testing.T) {
 	}
 }
 
+func TestLog(t *testing.T) {
+	worker := New(func(msg []byte) []byte {
+		t.Fatal("shouldn't recieve Message")
+		return nil
+	})
+	err := worker.Load("code.js", `V8Worker2.log("log message");`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSyntaxError(t *testing.T) {
 	worker := New(func(msg []byte) []byte {
 		t.Fatal("shouldn't recieve Message")


### PR DESCRIPTION
This commit makes sure any output from the worker code (rather than
the script being run) is printed to stderr; and gives V8Worker2 a
`log` method for printing to stderr, so the same can be done for the
jk runtime.